### PR TITLE
Share http4s version across build/docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,8 +109,9 @@ ThisBuild / Test / jsEnv := {
 
 val catsEffectVersion = "3.3.0"
 val fs2Version = "3.2.3"
-val http4sVersion = "0.23.7"
+val http4sVersion = buildinfo.BuildInfo.http4sVersion // share version with build project
 val scalaJSDomVersion = "2.0.0"
+val circeVersion = "0.15.0-M1"
 val munitVersion = "0.7.29"
 val munitCEVersion = "1.0.7"
 
@@ -183,7 +184,11 @@ lazy val docs =
     .settings(
       fatalWarningsInCI := false,
       mdocJS := Some(jsdocs),
-      mdocVariables += "js-opt" -> "fast",
+      mdocVariables ++= Map(
+        "js-opt" -> "fast",
+        "HTTP4S_VERSION" -> http4sVersion,
+        "CIRCE_VERSION" -> circeVersion
+      ),
       Laika / sourceDirectories := Seq(mdocOut.value),
       laikaDescribe := "<disabled>",
       laikaConfig ~= { _.withRawContent },

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,11 +21,11 @@ libraryDependencies += "org.http4s" %%% "http4s-dom" % "0.2.0"
 // libraryDependencies += "org.http4s" %%% "http4s-dom" % "0.1.0"
 
 // recommended, brings in the latest client module
-libraryDependencies += "org.http4s" %%% "http4s-client" % "0.23.7"
+libraryDependencies += "org.http4s" %%% "http4s-client" % "@HTTP4S_VERSION@"
 
 // optional, for JSON support
-libraryDependencies += "org.http4s" %%% "http4s-circe" % "0.23.7"
-libraryDependencies += "io.circe" %%% "circe-generic" % "0.15.0-M1"
+libraryDependencies += "org.http4s" %%% "http4s-circe" % "@HTTP4S_VERSION@"
+libraryDependencies += "io.circe" %%% "circe-generic" % "@CIRCE_VERSION@"
 ```
 
 ## Example

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,10 @@
+val http4sVersion = "0.23.7"
+
+enablePlugins(BuildInfoPlugin)
+buildInfoKeys += "http4sVersion" -> http4sVersion
+
 libraryDependencies += "org.scala-js" %% "scalajs-env-selenium" % "1.1.1"
-libraryDependencies += "org.http4s" %% "http4s-ember-server" % "0.23.7"
+libraryDependencies += "org.http4s" %% "http4s-ember-server" % http4sVersion
 
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.23.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")


### PR DESCRIPTION
Meta-build fun to reuse the http4s version across the project. Saves the manual work in https://github.com/http4s/http4s-dom/pull/54.