### PR TITLE
Switch back to fs2-core dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val dom = project
     description := "http4s browser integrations",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
-      "co.fs2" %%% "fs2-io" % fs2Version,
+      "co.fs2" %%% "fs2-core" % fs2Version,
       "org.http4s" %%% "http4s-client" % http4sVersion,
       "org.scala-js" %%% "scalajs-dom" % scalaJSDomVersion
     ),


### PR DESCRIPTION
The fs2-io dependency was a temporary workaround to evict the transitive version brought in by http4s-core. Actually none of the fs2-io APIs are usable in the browser, so it is a bit of a nonsense dependency.