### PR TITLE
Use fullname for `HTMLElement` and friends

### DIFF
--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -32,7 +32,7 @@ val fetchActivity: IO[Unit] = for {
   _ <- IO(activityElement.innerHTML = activity.activity)
 } yield ()
 
-val button = document.getElementById("button").asInstanceOf[html.Button]
+val button = document.getElementById("button").asInstanceOf[HTMLButtonElement]
 
 button.onclick = _ => fetchActivity.unsafeRunAndForget()
 ```

--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -28,15 +28,15 @@ import org.http4s.dom._
 import org.http4s.syntax.all._
 import org.scalajs.dom._
 
-val message = document.getElementById("message").asInstanceOf[html.Input]
-val button = document.getElementById("button").asInstanceOf[html.Button]
-val sent = document.getElementById("sent").asInstanceOf[html.Element]
-val received = document.getElementById("received").asInstanceOf[html.Element]
+val message = document.getElementById("message").asInstanceOf[HTMLInputElement]
+val button = document.getElementById("button").asInstanceOf[HTMLButtonElement]
+val sent = document.getElementById("sent").asInstanceOf[HTMLElement]
+val received = document.getElementById("received").asInstanceOf[HTMLElement]
 
 val request = WSRequest(uri"wss://ws.postman-echo.com/raw")
 val app = WebSocketClient[IO].connectHighLevel(request).use { conn =>
 
-  def log(e: html.Element, text: String): IO[Unit] =
+  def log(e: HTMLElement, text: String): IO[Unit] =
     IO {
       val p = document.createElement("p")
       p.innerHTML = text


### PR DESCRIPTION
This is just stupid bikeshedding. This switches to use the names as defined in JavaScript DOM APIs themselves rather than the convenience aliases provided in scala-js-dom.