### PR TITLE
Use `scalaJSLinkerOutputDirectory` to get worker dir

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,17 @@ lazy val tests = project
   .settings(
     scalaJSUseMainModuleInitializer := true,
     (Test / test) := (Test / test).dependsOn(Compile / fastOptJS).value,
-    buildInfoKeys := Seq[BuildInfoKey](scalaVersion, fileServicePort),
+    buildInfoKeys := Seq[BuildInfoKey](
+      fileServicePort,
+      BuildInfoKey("runtime" -> useJSEnv.value.toString),
+      BuildInfoKey(
+        "workerDir" -> (Compile / fastLinkJS / scalaJSLinkerOutputDirectory)
+          .value
+          .relativeTo((ThisBuild / baseDirectory).value)
+          .get
+          .toString
+      )
+    ),
     buildInfoPackage := "org.http4s.dom",
     libraryDependencies ++= Seq(
       "org.scalameta" %%% "munit" % munitVersion % Test,

--- a/tests/src/test/scala/org/http4s/dom/FetchServiceWorkerSuite.scala
+++ b/tests/src/test/scala/org/http4s/dom/FetchServiceWorkerSuite.scala
@@ -34,11 +34,6 @@ import scala.scalajs.js
 
 class FetchServiceWorkerSuite extends CatsEffectSuite {
 
-  def scalaVersion = if (BuildInfo.scalaVersion.startsWith("2"))
-    BuildInfo.scalaVersion.split("\\.").init.mkString(".")
-  else
-    BuildInfo.scalaVersion
-
   val client = FetchClientBuilder[IO].create
 
   val baseUrl = uri"/"
@@ -50,7 +45,7 @@ class FetchServiceWorkerSuite extends CatsEffectSuite {
           .navigator
           .serviceWorker
           .register(
-            s"/tests/target/scala-${scalaVersion}/tests-fastopt/main.js",
+            s"/${BuildInfo.workerDir}/main.js",
             js.Dynamic.literal(scope = "/")
           )
       }


### PR DESCRIPTION
This is more robust.