### PR TITLE
Revert "Update scalafmt-core to 3.7.0"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.0
+version = 3.6.1
 
 runner.dialect = Scala213Source3
 


### PR DESCRIPTION
Reverts http4s/http4s-dom#238

https://github.com/scalameta/scalafmt/issues/3438 impacts https://github.com/http4s/http4s-dom/pull/237