### PR TITLE
Make streaming requests opt-in

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,16 +123,24 @@ lazy val dom = project
     ),
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core._
-      if (tlIsScala3.value)
-        Seq(
-          ProblemFilters.exclude[DirectMissingMethodProblem](
-            "org.http4s.dom.package.closeReadableStream"),
-          ProblemFilters.exclude[DirectMissingMethodProblem](
-            "org.http4s.dom.package.fromReadableStream"),
-          ProblemFilters.exclude[DirectMissingMethodProblem](
-            "org.http4s.dom.package.toDomHeaders")
-        )
-      else Seq()
+      Seq(
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.http4s.dom.FetchClientBuilder.this"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("org.http4s.dom.FetchOptions.*"),
+        ProblemFilters.exclude[Problem]("org.http4s.dom.FetchOptions#FetchOptionsImpl*"),
+        ProblemFilters.exclude[Problem]("org.http4s.dom.FetchOptions$FetchOptionsImpl*")
+      ) ++ {
+        if (tlIsScala3.value)
+          Seq(
+            ProblemFilters.exclude[DirectMissingMethodProblem](
+              "org.http4s.dom.package.closeReadableStream"),
+            ProblemFilters.exclude[DirectMissingMethodProblem](
+              "org.http4s.dom.package.fromReadableStream"),
+            ProblemFilters.exclude[DirectMissingMethodProblem](
+              "org.http4s.dom.package.toDomHeaders")
+          )
+        else Seq()
+      }
     }
   )
   .enablePlugins(ScalaJSPlugin)

--- a/dom/src/main/scala/org/http4s/dom/FetchClientBuilder.scala
+++ b/dom/src/main/scala/org/http4s/dom/FetchClientBuilder.scala
@@ -57,7 +57,7 @@ sealed abstract class FetchClientBuilder[F[_]] private (
     val redirect: Option[RequestRedirect],
     val referrer: Option[FetchReferrer],
     val referrerPolicy: Option[ReferrerPolicy],
-    val streamingRequests: Boolean,
+    val streamingRequests: Boolean
 )(override implicit protected val F: Async[F])
     extends BackendBuilder[F, Client[F]] {
 
@@ -147,7 +147,8 @@ sealed abstract class FetchClientBuilder[F[_]] private (
       referrer = referrer,
       referrerPolicy = referrerPolicy,
       streamingRequests = streamingRequests
-    ))
+    )
+  )
 
   override def resource: Resource[F, Client[F]] =
     Resource.pure(create)

--- a/testsBrowser/src/test/scala/org/http4s/dom/FetchServiceWorkerSuite.scala
+++ b/testsBrowser/src/test/scala/org/http4s/dom/FetchServiceWorkerSuite.scala
@@ -89,6 +89,14 @@ class FetchServiceWorkerSuite extends CatsEffectSuite {
       .assertEquals("This is chunked.")
   }
 
+  test("POST a chunked body with streaming requests") {
+    FetchClientBuilder[IO]
+      .withStreamingRequests
+      .create
+      .expect[String](POST(Stream("This is chunked.").covary[IO], baseUrl / "echo"))
+      .assertEquals("This is chunked.")
+  }
+
   test("POST a multipart body") {
     Multiparts.forSync[IO].flatMap { multiparts =>
       multiparts


### PR DESCRIPTION
Unfortunately I was a bit over-eager with enabling this 😕  according to the blog post there are a number of situations where attempting to use streaming requests will simply reject the request.

> if the request has a streaming body, and the response is an HTTP redirect other than 303, the fetch will reject and the redirect will not be followed.

> Streaming no-cors requests are not allowed.

> The fetch will be rejected if the connection is HTTP/1.x.

> this feature only works over HTTPS

https://developer.chrome.com/articles/fetch-streaming-requests/

In retrospect, it was extremely dumb of me to enable this by default. Fortunately, no bug reports 😇 

Anyway, now it is an opt-in option on `FetchOptions`, and can be set at either the client-level or the request-level.