### PR TITLE
Fix `receive` on websocket closure

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,9 @@ Global / fileServicePort := {
   import cats.effect.IO
   import cats.effect.unsafe.implicits.global
   import com.comcast.ip4s._
+  import fs2.Stream
   import org.http4s._
+  import org.http4s.websocket._
   import org.http4s.dsl.io._
   import org.http4s.ember.server.EmberServerBuilder
   import org.http4s.server.staticcontent._
@@ -69,6 +71,8 @@ Global / fileServicePort := {
               wsb.build(identity)
             case Method.GET -> Root / "slows" =>
               IO.sleep(3.seconds) *> wsb.build(identity)
+            case Method.GET -> Root / "hello-goodbye" =>
+              wsb.build(in => Stream(WebSocketFrame.Text("hello")).concurrently(in.drain))
             case req =>
               fileService[IO](FileService.Config[IO](".")).orNotFound.run(req).map { res =>
                 // TODO find out why mime type is not auto-inferred

--- a/testsBrowser/src/test/scala/org/http4s/dom/WebSocketSuite.scala
+++ b/testsBrowser/src/test/scala/org/http4s/dom/WebSocketSuite.scala
@@ -70,4 +70,18 @@ class WebSocketSuite extends CatsEffectSuite {
       }
   }
 
+  test("receive returns None when connection closes") {
+    WebSocketClient[IO]
+      .connectHighLevel(
+        WSRequest(
+          Uri.fromString(s"ws://localhost:${fileServicePort}/hello-goodbye").toOption.get)
+      )
+      .use { conn =>
+        conn.receive.assertEquals(Some(WSFrame.Text("hello"))) *>
+          conn.receive.assertEquals(None) *>
+          conn.receive.assertEquals(None) *>
+          conn.receiveStream.compile.toList.assertEquals(Nil)
+      }
+  }
+
 }


### PR DESCRIPTION
Ensures that we return `None` / an empty `Stream` if called continually after the socket has closed.